### PR TITLE
Updated build.release.gradle to make repository 'compile' end-of-life…

### DIFF
--- a/FtcRobotController/build.release.gradle
+++ b/FtcRobotController/build.release.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    compile (name:'Inspection-release', ext: 'aar')
-    compile (name:'Blocks-release', ext: 'aar')
-    compile (name:'RobotCore-release', ext: 'aar')
-    compile (name:'Hardware-release', ext: 'aar')
-    compile (name:'FtcCommon-release', ext: 'aar')
-    compile (name:'WirelessP2p-release', ext:'aar')
+    implementation (name:'Inspection-release', ext: 'aar')
+    implementation (name:'Blocks-release', ext: 'aar')
+    implementation (name:'RobotCore-release', ext: 'aar')
+    implementation (name:'Hardware-release', ext: 'aar')
+    implementation (name:'FtcCommon-release', ext: 'aar')
+    implementation (name:'WirelessP2p-release', ext:'aar')
 }


### PR DESCRIPTION
Changed all instances of 'compile' to 'implementation' to increase stability, and to prevent problems at the end of 2018.